### PR TITLE
MCglTF-Example-1.16.5-Forge-2.0.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.16.5-Forge-1.2.0.0'
-group = 'com.timlee9024.mcgltf.example' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+version = '1.16.5-Forge-2.0.0.0'
+group = 'com.modularmods.mcgltf.example' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'MCglTF-Example'
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(8) // Mojang ships Java 8 to end users, so your mod should target Java 8.
@@ -157,7 +157,7 @@ jar {
     manifest {
         attributes([
             "Specification-Title": "MCglTF-Example",
-            "Specification-Vendor": "TimLee9024",
+            "Specification-Vendor": "ModularMods",
             "Specification-Version": "1", // We are version 1 of ourselves
             "Implementation-Title": project.name,
             "Implementation-Version": "${version}",

--- a/src/main/java/com/modularmods/mcgltf/example/Example.java
+++ b/src/main/java/com/modularmods/mcgltf/example/Example.java
@@ -1,7 +1,7 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
-import com.timlee9024.mcgltf.MCglTF;
+import com.modularmods.mcgltf.MCglTF;
 
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleBlock.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleBlock.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleEntity.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleEntity.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.merchant.villager.VillagerEntity;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleEntityRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleEntityRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -6,17 +6,15 @@ import java.util.List;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.lwjgl.opengl.GL13;
-import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL30;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
@@ -92,11 +90,6 @@ public class ExampleEntityRenderer extends EntityRenderer<ExampleEntity> impleme
 			GL13.glActiveTexture(GL13.GL_TEXTURE0);
 			renderedScene.renderForVanilla();
 		}
-		
-		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
-		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);
-		GL30.glBindVertexArray(0);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
 		
 		GL11.glPopAttrib();
 		GL11.glPopMatrix();

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleItemRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleItemRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -6,17 +6,15 @@ import java.util.List;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.lwjgl.opengl.GL13;
-import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL30;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.minecraft.client.Minecraft;
@@ -111,11 +109,6 @@ public abstract class ExampleItemRenderer implements IGltfModelReceiver {
 		default:
 			break;
 		}
-		
-		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
-		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);
-		GL30.glBindVertexArray(0);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
 		
 		GL11.glPopAttrib();
 		GL11.glPopMatrix();

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleTileEntity.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleTileEntity.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.tileentity.TileEntity;
 

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleTileEntityRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleTileEntityRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -6,17 +6,15 @@ import java.util.List;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.lwjgl.opengl.GL13;
-import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL30;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.minecraft.block.HorizontalBlock;
@@ -113,11 +111,6 @@ public class ExampleTileEntityRenderer extends TileEntityRenderer<ExampleTileEnt
 			GL13.glActiveTexture(GL13.GL_TEXTURE0);
 			renderedScene.renderForVanilla();
 		}
-		
-		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
-		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);
-		GL30.glBindVertexArray(0);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
 		
 		GL11.glPopAttrib();
 		GL11.glPopMatrix();

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -11,7 +11,7 @@ loaderVersion="[36,)" #mandatory This is typically bumped every Minecraft versio
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="MIT License"
 # A URL to refer people to when problems occur with this mod
-issueTrackerURL="https://github.com/TimLee9024/MCglTF-Example/issues/" #optional
+issueTrackerURL="https://github.com/ModularMods/MCglTF-Example/issues/" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod
@@ -23,15 +23,15 @@ version="${file.jarVersion}" #mandatory
  # A display name for the mod
 displayName="Example MCglTF Usage" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification https://mcforge.readthedocs.io/en/latest/gettingstarted/autoupdate/
-updateJSONURL="https://raw.githubusercontent.com/TimLee9024/MCglTF-Example/1.16.5-Forge/updates.json" #optional
+updateJSONURL="https://raw.githubusercontent.com/ModularMods/MCglTF-Example/1.16.5-Forge/updates.json" #optional
 # A URL for the "homepage" for this mod, displayed in the mod UI
-displayURL="https://github.com/TimLee9024/MCglTF-Example/tree/1.16.5-Forge/" #optional
+displayURL="https://github.com/ModularMods/MCglTF-Example/tree/1.16.5-Forge/" #optional
 # A file name (in the root of the mod JAR) containing a logo for display
 logoFile="icon.png" #optional
 # A text field displayed in the mod UI
 credits="Microsoft and Cesium, for providing glTF sample models" #optional
 # A text field displayed in the mod UI
-authors="TimLee9024" #optional
+authors="TimLee9024, Protoxy" #optional
 # The description text for the mod (multi line!) (#mandatory)
 description='''
 Example mod to demonstrate the usage of MCglTF.
@@ -58,7 +58,7 @@ Example mod to demonstrate the usage of MCglTF.
     side="BOTH"
 [[dependencies.example_mcgltf_usage]]
     modId="mcgltf"
-    mandatory=false
-    versionRange="[1.16.5-Forge-1.1.0.0,)"
+    mandatory=true
+    versionRange="[1.16.5-Forge-2.0.0.0,)"
     ordering="AFTER"
     side="CLIENT"

--- a/updates.json
+++ b/updates.json
@@ -1,5 +1,5 @@
 {
-	"homepage": "https://github.com/TimLee9024/MCglTF-Example/releases",
+	"homepage": "https://github.com/ModularMods/MCglTF-Example/releases",
 	"1.16.5": {
 		"1.16.5-Forge-2.0.0.0": "Update to compatible with MCglTF-2.0.0.0",
 		"1.16.5-Forge-1.2.0.0": "Update to compatible with MCglTF-1.2.0.0",

--- a/updates.json
+++ b/updates.json
@@ -1,13 +1,14 @@
 {
 	"homepage": "https://github.com/TimLee9024/MCglTF-Example/releases",
 	"1.16.5": {
+		"1.16.5-Forge-2.0.0.0": "Update to compatible with MCglTF-2.0.0.0",
 		"1.16.5-Forge-1.2.0.0": "Update to compatible with MCglTF-1.2.0.0",
 		"1.16.5-Forge-1.1.0.1": "Fix homepage URL and server side item registration",
 		"1.16.5-Forge-1.1.0.0": "Update to work with MCglTF version 1.16.5-Forge-1.1.0.0",
 		"1.16.5-Forge-1.0.0.0": "Initial release"
 	},
 	"promos": {
-		"1.16.5-latest": "1.16.5-Forge-1.2.0.0",
-		"1.16.5-recommended": "1.16.5-Forge-1.2.0.0"
+		"1.16.5-latest": "1.16.5-Forge-2.0.0.0",
+		"1.16.5-recommended": "1.16.5-Forge-2.0.0.0"
 	}
 }


### PR DESCRIPTION
Update to compatible with MCglTF-2.0.0.0
- Change namespace from `com.timlee9024.mcgltf` to `com.modularmods.mcgltf`.
- Move `nodeGlobalTransformLookup.clear()` (rename to `NODE_GLOBAL_TRANSFORMATION_LOOKUP_CACHE`) from MCglTF-Example to `RenderedGltfScene#renderForVanilla()` and `RenderedGltfScene#renderForShaderMod()`.
- 1.12.2 and 1.16.5: Move `GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);`, `GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);`, and `GL30.glBindVertexArray(0);` from MCglTF-Example to `RenderedGltfScene#renderForVanilla()` and `RenderedGltfScene#renderForShaderMod()` for OpenGL compatibility.