### PR TITLE
MCglTF-Example-1.18.2-Forge-2.0.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle'
 
 
-version = '1.18.2-Forge-1.2.0.0'
-group = 'com.timlee9024.mcgltf.example' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+version = '1.18.2-Forge-2.0.0.0'
+group = 'com.modularmods.mcgltf.example' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'MCglTF-Example'
 
 // Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
@@ -151,7 +151,7 @@ dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.18.2-40.1.69'
+    minecraft 'net.minecraftforge:forge:1.18.2-40.1.84'
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency
@@ -173,7 +173,7 @@ jar {
     manifest {
         attributes([
                 "Specification-Title"     : "MCglTF-Example",
-                "Specification-Vendor"    : "TimLee9024",
+                "Specification-Vendor"    : "ModularMods",
                 "Specification-Version"   : "1", // We are version 1 of ourselves
                 "Implementation-Title"    : project.name,
                 "Implementation-Version"  : project.jar.archiveVersion,

--- a/src/main/java/com/modularmods/mcgltf/example/Example.java
+++ b/src/main/java/com/modularmods/mcgltf/example/Example.java
@@ -1,9 +1,9 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.function.Consumer;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.timlee9024.mcgltf.MCglTF;
+import com.modularmods.mcgltf.MCglTF;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleBlock.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleBlock.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntity.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntity.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntityRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntityRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,12 +11,12 @@ import org.lwjgl.opengl.GL30;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Quaternion;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -139,7 +139,6 @@ public class ExampleBlockEntityRenderer implements IGltfModelReceiver, BlockEnti
 		GL30.glBindVertexArray(currentVAO);
 		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, currentArrayBuffer);
 		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, currentElementArrayBuffer);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
 	}
 
 }

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleEntity.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleEntity.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.npc.Villager;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleEntityRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleEntityRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,12 +11,12 @@ import org.lwjgl.opengl.GL30;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Quaternion;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -122,7 +122,6 @@ public class ExampleEntityRenderer extends EntityRenderer<ExampleEntity> impleme
 		GL30.glBindVertexArray(currentVAO);
 		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, currentArrayBuffer);
 		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, currentElementArrayBuffer);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
 		super.render(p_114485_, p_114486_, p_114487_, p_114488_, p_114489_, p_114490_);
 	}
 

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleItemRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleItemRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,12 +13,12 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Matrix3f;
 import com.mojang.math.Quaternion;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.minecraft.client.Minecraft;
@@ -190,7 +190,6 @@ public abstract class ExampleItemRenderer implements IGltfModelReceiver {
 		GL30.glBindVertexArray(currentVAO);
 		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, currentArrayBuffer);
 		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, currentElementArrayBuffer);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
 	}
 
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -11,7 +11,7 @@ loaderVersion="[40,)" #mandatory This is typically bumped every Minecraft versio
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="MIT License"
 # A URL to refer people to when problems occur with this mod
-issueTrackerURL="https://github.com/TimLee9024/MCglTF-Example/issues/" #optional
+issueTrackerURL="https://github.com/ModularMods/MCglTF-Example/issues/" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod
@@ -23,15 +23,15 @@ version="${file.jarVersion}" #mandatory
  # A display name for the mod
 displayName="Example MCglTF Usage" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification https://mcforge.readthedocs.io/en/latest/gettingstarted/autoupdate/
-updateJSONURL="https://raw.githubusercontent.com/TimLee9024/MCglTF-Example/1.18.2-Forge/updates.json" #optional
+updateJSONURL="https://raw.githubusercontent.com/ModularMods/MCglTF-Example/1.18.2-Forge/updates.json" #optional
 # A URL for the "homepage" for this mod, displayed in the mod UI
-displayURL="https://github.com/TimLee9024/MCglTF-Example/tree/1.18.2-Forge/" #optional
+displayURL="https://github.com/ModularMods/MCglTF-Example/tree/1.18.2-Forge/" #optional
 # A file name (in the root of the mod JAR) containing a logo for display
 logoFile="icon.png" #optional
 # A text field displayed in the mod UI
 credits="Microsoft and Cesium, for providing glTF sample models" #optional
 # A text field displayed in the mod UI
-authors="TimLee9024" #optional
+authors="TimLee9024, Protoxy" #optional
 # The description text for the mod (multi line!) (#mandatory)
 description='''
 Example mod to demonstrate the usage of MCglTF.
@@ -58,7 +58,7 @@ Example mod to demonstrate the usage of MCglTF.
     side="BOTH"
 [[dependencies.example_mcgltf_usage]]
     modId="mcgltf"
-    mandatory=false
-    versionRange="[1.18.2-Forge-1.0.0.0,)"
+    mandatory=true
+    versionRange="[1.18.2-Forge-2.0.0.0,)"
     ordering="AFTER"
     side="CLIENT"

--- a/updates.json
+++ b/updates.json
@@ -1,13 +1,14 @@
 {
-	"homepage": "https://github.com/TimLee9024/MCglTF-Example/releases",
+	"homepage": "https://github.com/ModularMods/MCglTF-Example/releases",
 	"1.18.2": {
+		"1.18.2-Forge-2.0.0.0": "Update to compatible with MCglTF-2.0.0.0",
 		"1.18.2-Forge-1.2.0.0": "Update to compatible with MCglTF-1.2.0.0",
 		"1.18.2-Forge-1.0.0.2": "Fix registry name of block item is incorrect on server",
 		"1.18.2-Forge-1.0.0.1": "Fix depth test sometime not enable on GUI Item",
 		"1.18.2-Forge-1.0.0.0": "Initial release"
 	},
 	"promos": {
-		"1.18.2-latest": "1.18.2-Forge-1.2.0.0",
-		"1.18.2-recommended": "1.18.2-Forge-1.2.0.0"
+		"1.18.2-latest": "1.18.2-Forge-2.0.0.0",
+		"1.18.2-recommended": "1.18.2-Forge-2.0.0.0"
 	}
 }


### PR DESCRIPTION
Update to compatible with MCglTF-2.0.0.0
- Change namespace from `com.timlee9024.mcgltf` to `com.modularmods.mcgltf`.
- Move `nodeGlobalTransformLookup.clear()` (rename to `NODE_GLOBAL_TRANSFORMATION_LOOKUP_CACHE`) from MCglTF-Example to `RenderedGltfScene#renderForVanilla()` and `RenderedGltfScene#renderForShaderMod()`.
- 1.12.2 and 1.16.5: Move `GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);`, `GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);`, and `GL30.glBindVertexArray(0);` from MCglTF-Example to `RenderedGltfScene#renderForVanilla()` and `RenderedGltfScene#renderForShaderMod()` for OpenGL compatibility.