### PR TITLE
MCglTF-Example-1.16.5-Fabric-2.0.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.0-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ org.gradle.jvmargs=-Xmx4G
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
 	minecraft_version=1.16.5
-	loader_version=0.14.8
+	loader_version=0.14.10
 
 # Mod Properties
-	mod_version = 1.16.5-Fabric-1.0.0.0
-	maven_group = com.timlee9024.mcgltf.example
+	mod_version = 1.16.5-Fabric-2.0.0.0
+	maven_group = com.modularmods.mcgltf.example
 	archives_base_name = MCglTF-Example
 
 # Dependencies

--- a/src/main/java/com/modularmods/mcgltf/example/Example.java
+++ b/src/main/java/com/modularmods/mcgltf/example/Example.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleBlock.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleBlock.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntity.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntity.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.world.level.block.entity.BlockEntity;
 

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntityRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntityRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -6,17 +6,15 @@ import java.util.List;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.lwjgl.opengl.GL13;
-import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL30;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -112,11 +110,6 @@ public class ExampleBlockEntityRenderer extends BlockEntityRenderer<ExampleBlock
 			GL13.glActiveTexture(GL13.GL_TEXTURE0);
 			renderedScene.renderForVanilla();
 		}
-		
-		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
-		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);
-		GL30.glBindVertexArray(0);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
 		
 		GL11.glPopAttrib();
 		GL11.glPopMatrix();

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleClient.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleClient.java
@@ -1,6 +1,6 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
-import com.timlee9024.mcgltf.MCglTF;
+import com.modularmods.mcgltf.MCglTF;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendereregistry.v1.BlockEntityRendererRegistry;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleEntity.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleEntity.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.npc.Villager;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleEntityRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleEntityRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -6,17 +6,15 @@ import java.util.List;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.lwjgl.opengl.GL13;
-import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL30;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -91,11 +89,6 @@ public class ExampleEntityRenderer extends EntityRenderer<ExampleEntity> impleme
 			GL13.glActiveTexture(GL13.GL_TEXTURE0);
 			renderedScene.renderForVanilla();
 		}
-		
-		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
-		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);
-		GL30.glBindVertexArray(0);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
 		
 		GL11.glPopAttrib();
 		GL11.glPopMatrix();

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleItemRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleItemRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -6,17 +6,15 @@ import java.util.List;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.lwjgl.opengl.GL13;
-import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL30;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
@@ -113,11 +111,6 @@ public abstract class ExampleItemRenderer implements IGltfModelReceiver, Builtin
 		default:
 			break;
 		}
-		
-		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
-		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);
-		GL30.glBindVertexArray(0);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
 		
 		GL11.glPopAttrib();
 		GL11.glPopMatrix();

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -6,12 +6,12 @@
   "name": "Example MCglTF Usage",
   "description": "Example mod to demonstrate the usage of MCglTF.",
   "authors": [
-    "TimLee9024"
+    "TimLee9024", "Protoxy"
   ],
   "contact": {
-    "homepage": "https://github.com/TimLee9024/MCglTF-Example/tree/1.16.5-Fabric",
-    "sources": "https://github.com/TimLee9024/MCglTF-Example/tree/1.16.5-Fabric",
-    "issues": "https://github.com/TimLee9024/MCglTF-Example/issues"
+    "homepage": "https://github.com/ModularMods/MCglTF-Example/tree/1.16.5-Fabric",
+    "sources": "https://github.com/ModularMods/MCglTF-Example/tree/1.16.5-Fabric",
+    "issues": "https://github.com/ModularMods/MCglTF-Example/issues"
   },
 
   "license": "MIT",
@@ -20,10 +20,10 @@
   "environment": "*",
   "entrypoints": {
     "main": [
-      "com.timlee9024.mcgltf.example.Example"
+      "com.modularmods.mcgltf.example.Example"
     ],
     "client": [
-      "com.timlee9024.mcgltf.example.ExampleClient"
+      "com.modularmods.mcgltf.example.ExampleClient"
     ]
   },
 


### PR DESCRIPTION
Update to compatible with MCglTF-2.0.0.0
- Change namespace from `com.timlee9024.mcgltf` to `com.modularmods.mcgltf`.
- Move `nodeGlobalTransformLookup.clear()` (rename to `NODE_GLOBAL_TRANSFORMATION_LOOKUP_CACHE`) from MCglTF-Example to `RenderedGltfScene#renderForVanilla()` and `RenderedGltfScene#renderForShaderMod()`.
- 1.12.2 and 1.16.5: Move `GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);`, `GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);`, and `GL30.glBindVertexArray(0);` from MCglTF-Example to `RenderedGltfScene#renderForVanilla()` and `RenderedGltfScene#renderForShaderMod()` for OpenGL compatibility.