### PR TITLE
MCglTF-Example-1.18.2-Fabric-2.0.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.0-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.jvmargs=-Xmx4G
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
 	minecraft_version=1.18.2
-	loader_version=0.14.8
+	loader_version=0.14.10
 
 # Mod Properties
-	mod_version = 1.18.2-Fabric-1.0.0.0
-	maven_group = com.timlee9024.mcgltf.example
+	mod_version = 1.18.2-Fabric-2.0.0.0
+	maven_group = com.modularmods.mcgltf.example
 	archives_base_name = MCglTF-Example
 
 # Dependencies
-	fabric_version=0.58.0+1.18.2
+	fabric_version=0.59.1+1.18.2

--- a/src/main/java/com/modularmods/mcgltf/example/Example.java
+++ b/src/main/java/com/modularmods/mcgltf/example/Example.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleBlock.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleBlock.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntity.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntity.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntityRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleBlockEntityRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,33 +11,30 @@ import org.lwjgl.opengl.GL30;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Quaternion;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.entity.EntityRenderer;
-import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Mth;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 
-public class ExampleEntityRenderer extends EntityRenderer<ExampleEntity> implements IGltfModelReceiver {
+public class ExampleBlockEntityRenderer implements IGltfModelReceiver, BlockEntityRenderer<ExampleBlockEntity> {
 
 	protected RenderedGltfScene renderedScene;
 	
 	protected List<List<InterpolatedChannel>> animations;
 	
-	protected ExampleEntityRenderer(EntityRendererProvider.Context p_174008_) {
-		super(p_174008_);
-	}
-
 	@Override
 	public ResourceLocation getModelLocation() {
-		return new ResourceLocation("mcgltf", "models/entity/cesium_man.gltf");
+		return new ResourceLocation("mcgltf", "models/block/boom_box.gltf");
 	}
 
 	@Override
@@ -50,22 +47,12 @@ public class ExampleEntityRenderer extends EntityRenderer<ExampleEntity> impleme
 		}
 	}
 
+	/**
+	 * Since you use custom BEWLR(DynamicItemRenderer) for BlockItem instead of BER to render item form of block,
+	 * the last parameters p_112312_ which control overlay color is almost never used.
+	 */
 	@Override
-	public ResourceLocation getTextureLocation(ExampleEntity p_114482_) {
-		return null;
-	}
-
-	@Override
-	public void render(ExampleEntity p_114485_, float p_114486_, float p_114487_, PoseStack p_114488_, MultiBufferSource p_114489_, int p_114490_) {
-		float time = (p_114485_.level.getGameTime() + p_114487_) / 20;
-		//Play every animation clips simultaneously
-		for(List<InterpolatedChannel> animation : animations) {
-			animation.parallelStream().forEach((channel) -> {
-				float[] keys = channel.getKeys();
-				channel.update(time % keys[keys.length - 1]);
-			});
-		}
-		
+	public void render(ExampleBlockEntity p_112307_, float p_112308_, PoseStack p_112309_, MultiBufferSource p_112310_, int p_112311_, int p_112312_) {
 		int currentVAO = GL11.glGetInteger(GL30.GL_VERTEX_ARRAY_BINDING);
 		int currentArrayBuffer = GL11.glGetInteger(GL15.GL_ARRAY_BUFFER_BINDING);
 		int currentElementArrayBuffer = GL11.glGetInteger(GL15.GL_ELEMENT_ARRAY_BUFFER_BINDING);
@@ -78,13 +65,43 @@ public class ExampleEntityRenderer extends EntityRenderer<ExampleEntity> impleme
 		GL11.glEnable(GL11.GL_BLEND);
 		GlStateManager._blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 		
-		p_114488_.pushPose();
-		p_114488_.mulPose(new Quaternion(0.0F, Mth.rotLerp(p_114487_, p_114485_.yBodyRotO, p_114485_.yBodyRot), 0.0F, true));
-		RenderedGltfModel.CURRENT_POSE = p_114488_.last().pose();
-		RenderedGltfModel.CURRENT_NORMAL = p_114488_.last().normal();
-		p_114488_.popPose();
+		p_112309_.pushPose();
+		Level level = p_112307_.getLevel();
+		if(level != null) {
+			float time = (level.getGameTime() + p_112308_) / 20;
+			//Play every animation clips simultaneously
+			for(List<InterpolatedChannel> animation : animations) {
+				animation.parallelStream().forEach((channel) -> {
+					float[] keys = channel.getKeys();
+					channel.update(time % keys[keys.length - 1]);
+				});
+			}
+			
+			p_112309_.translate(0.5, 0.5, 0.5); //Make sure it is in the center of the block
+			switch(level.getBlockState(p_112307_.getBlockPos()).getOptionalValue(HorizontalDirectionalBlock.FACING).orElse(Direction.NORTH)) {
+			case DOWN:
+				break;
+			case UP:
+				break;
+			case NORTH:
+				break;
+			case SOUTH:
+				p_112309_.mulPose(new Quaternion(0.0F, 1.0F, 0.0F, 0.0F));
+				break;
+			case WEST:
+				p_112309_.mulPose(new Quaternion(0.0F, 0.7071068F, 0.0F, 0.7071068F));
+				break;
+			case EAST:
+				p_112309_.mulPose(new Quaternion(0.0F, -0.7071068F, 0.0F, 0.7071068F));
+				break;
+			}
+		}
 		
-		GL30.glVertexAttribI2i(RenderedGltfModel.vaUV2, p_114490_ & '\uffff', p_114490_ >> 16 & '\uffff');
+		RenderedGltfModel.CURRENT_POSE = p_112309_.last().pose();
+		RenderedGltfModel.CURRENT_NORMAL = p_112309_.last().normal();
+		p_112309_.popPose();
+		
+		GL30.glVertexAttribI2i(RenderedGltfModel.vaUV2, p_112311_ & '\uffff', p_112311_ >> 16 & '\uffff');
 		
 		if(MCglTF.getInstance().isShaderModActive()) {
 			renderedScene.renderForShaderMod();
@@ -122,8 +139,6 @@ public class ExampleEntityRenderer extends EntityRenderer<ExampleEntity> impleme
 		GL30.glBindVertexArray(currentVAO);
 		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, currentArrayBuffer);
 		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, currentElementArrayBuffer);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
-		super.render(p_114485_, p_114486_, p_114487_, p_114488_, p_114489_, p_114490_);
 	}
 
 }

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleClient.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleClient.java
@@ -1,6 +1,6 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
-import com.timlee9024.mcgltf.MCglTF;
+import com.modularmods.mcgltf.MCglTF;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.BlockEntityRendererRegistry;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleEntity.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleEntity.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.npc.Villager;

--- a/src/main/java/com/modularmods/mcgltf/example/ExampleItemRenderer.java
+++ b/src/main/java/com/modularmods/mcgltf/example/ExampleItemRenderer.java
@@ -1,4 +1,4 @@
-package com.timlee9024.mcgltf.example;
+package com.modularmods.mcgltf.example;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,12 +13,12 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Matrix3f;
 import com.mojang.math.Quaternion;
-import com.timlee9024.mcgltf.IGltfModelReceiver;
-import com.timlee9024.mcgltf.MCglTF;
-import com.timlee9024.mcgltf.RenderedGltfModel;
-import com.timlee9024.mcgltf.RenderedGltfScene;
-import com.timlee9024.mcgltf.animation.GltfAnimationCreator;
-import com.timlee9024.mcgltf.animation.InterpolatedChannel;
+import com.modularmods.mcgltf.IGltfModelReceiver;
+import com.modularmods.mcgltf.MCglTF;
+import com.modularmods.mcgltf.RenderedGltfModel;
+import com.modularmods.mcgltf.RenderedGltfScene;
+import com.modularmods.mcgltf.animation.GltfAnimationCreator;
+import com.modularmods.mcgltf.animation.InterpolatedChannel;
 
 import de.javagl.jgltf.model.AnimationModel;
 import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
@@ -192,7 +192,6 @@ public abstract class ExampleItemRenderer implements IGltfModelReceiver, Builtin
 		GL30.glBindVertexArray(currentVAO);
 		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, currentArrayBuffer);
 		GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, currentElementArrayBuffer);
-		RenderedGltfModel.nodeGlobalTransformLookup.clear();
 	}
 
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -6,12 +6,12 @@
   "name": "Example MCglTF Usage",
   "description": "Example mod to demonstrate the usage of MCglTF.",
   "authors": [
-    "TimLee9024"
+    "TimLee9024", "Protoxy"
   ],
   "contact": {
-    "homepage": "https://github.com/TimLee9024/MCglTF-Example/tree/1.18.2-Fabric",
-    "sources": "https://github.com/TimLee9024/MCglTF-Example/tree/1.18.2-Fabric",
-    "issues": "https://github.com/TimLee9024/MCglTF-Example/issues"
+    "homepage": "https://github.com/ModularMods/MCglTF-Example/tree/1.18.2-Fabric",
+    "sources": "https://github.com/ModularMods/MCglTF-Example/tree/1.18.2-Fabric",
+    "issues": "https://github.com/ModularMods/MCglTF-Example/issues"
   },
 
   "license": "MIT",
@@ -20,10 +20,10 @@
   "environment": "*",
   "entrypoints": {
     "main": [
-      "com.timlee9024.mcgltf.example.Example"
+      "com.modularmods.mcgltf.example.Example"
     ],
     "client": [
-      "com.timlee9024.mcgltf.example.ExampleClient"
+      "com.modularmods.mcgltf.example.ExampleClient"
     ]
   },
 


### PR DESCRIPTION
Update to compatible with MCglTF-2.0.0.0
- Change namespace from `com.timlee9024.mcgltf` to `com.modularmods.mcgltf`.
- Move `nodeGlobalTransformLookup.clear()` (rename to `NODE_GLOBAL_TRANSFORMATION_LOOKUP_CACHE`) from MCglTF-Example to `RenderedGltfScene#renderForVanilla()` and `RenderedGltfScene#renderForShaderMod()`.
- 1.12.2 and 1.16.5: Move `GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);`, `GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);`, and `GL30.glBindVertexArray(0);` from MCglTF-Example to `RenderedGltfScene#renderForVanilla()` and `RenderedGltfScene#renderForShaderMod()` for OpenGL compatibility.